### PR TITLE
Set up Gson support for common Admin SDK API 'GET' responses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,12 @@
       <artifactId>appengine-api-1.0-sdk</artifactId>
       <version>1.9.59</version>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.12</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/google/sps/data/AnnotatedField.java
+++ b/src/main/java/com/google/sps/data/AnnotatedField.java
@@ -1,0 +1,35 @@
+package com.google.sps.data;
+
+public enum AnnotatedField {
+  ASSET_ID {
+    public String getField(ChromeOSDevice device) {
+      return device.getAnnotatedAssetId();
+    }
+  },
+  LOCATION {
+    public String getField(ChromeOSDevice device) {
+      return device.getAnnotatedLocation();
+    }
+  },
+  USER {
+    public String getField(ChromeOSDevice device) {
+      return device.getAnnotatedUser();
+    }
+  };
+
+  public abstract String getField(ChromeOSDevice device);
+
+
+  public static AnnotatedField create(String fieldName) {
+    switch (fieldName) {
+      case "annotatedAssetId":
+        return AnnotatedField.ASSET_ID;
+      case "annotatedLocation":
+        return AnnotatedField.LOCATION;
+      case "annotatedUser":
+        return AnnotatedField.USER;
+      default:
+        throw new IllegalArgumentException("Invalid annotated field name: '" + fieldName + "'");
+    }
+  }
+}

--- a/src/main/java/com/google/sps/data/ChromeOSDevice.java
+++ b/src/main/java/com/google/sps/data/ChromeOSDevice.java
@@ -6,13 +6,13 @@ package com.google.sps.data;
  * This class is an incomplete list of all chrome os device properties, instead containing
  * only the subset of properties related to the webapp.  These properties can be expanded
  * if the scope changes.
+ * ChromeOSDevice should not be mutated.
  */
 public class ChromeOSDevice {
 
   private String annotatedAssetId;
   private String annotatedLocation;
   private String annotatedUser;
-
   private final String deviceId;
   private final String serialNumber;
 
@@ -27,27 +27,34 @@ public class ChromeOSDevice {
     this.annotatedUser = annotatedUser;
     this.deviceId = deviceId;
     this.serialNumber = serialNumber;
-
     sanitize();
   }
 
-  // The Gson deserializer doesnt actually call the object's constructor, so we defined a custom
+  // The Gson deserializer doesn't actually call the object's constructor, so we defined a custom
   // deserializer which calls the sanitize() method. To keep everything consistent, the
   // ChromeOSDevice constructor also calls the sanitize() method so the same standard is held
   public void sanitize() {
-    annotatedAssetId = annotatedAssetId == null ? "" : annotatedAssetId;
-    annotatedLocation = annotatedLocation == null ? "" : annotatedLocation;
-    annotatedUser = annotatedUser == null ? "" : annotatedUser;
+    annotatedAssetId = (annotatedAssetId == null) ? "" : annotatedAssetId;
+    annotatedLocation = (annotatedLocation == null) ? "" : annotatedLocation;
+    annotatedUser = (annotatedUser == null) ? "" : annotatedUser;
+  }
+
+  public ChromeOSDevice copy() {
+    return new ChromeOSDevice(getAnnotatedAssetId(),
+                              getAnnotatedLocation(),
+                              getAnnotatedUser(),
+                              getDeviceId(),
+                              getSerialNumber());
   }
 
   public String getAnnotatedField(String fieldName) throws IllegalArgumentException {
     switch(fieldName) {
       case "annotatedAssetId":
-        return annotatedAssetId;
+        return getAnnotatedAssetId();
       case "annotatedLocation":
-        return annotatedLocation;
+        return getAnnotatedLocation();
       case "annotatedUser":
-        return annotatedUser;
+        return getAnnotatedUser();
       default:
         throw new IllegalArgumentException(fieldName + "is not a valid annotated field");
     }
@@ -57,21 +64,47 @@ public class ChromeOSDevice {
     return deviceId;
   }
 
+
+  public String getSerialNumber() {
+    return serialNumber;
+  }
+
+
+  public String getAnnotatedAssetId() {
+    return annotatedAssetId;
+  }
+
+
+  public String getAnnotatedLocation() {
+    return annotatedLocation;
+  }
+
+
+  public String getAnnotatedUser() {
+    return annotatedUser;
+  }
+
   @Override
   public boolean equals(Object obj) {
     if (obj == this) {
       return true;
     }
-
     if (!(obj instanceof ChromeOSDevice)) {
       return false;
     }
+    return comparable((ChromeOSDevice) obj);
+  }
 
-    ChromeOSDevice other = (ChromeOSDevice) obj;
-    return annotatedAssetId.equals(other.annotatedAssetId) &&
-        annotatedLocation.equals(other.annotatedLocation) &&
-        annotatedUser.equals(other.annotatedUser) &&
-        deviceId.equals(other.deviceId) &&
-        serialNumber.equals(other.serialNumber);
+  private boolean comparable(ChromeOSDevice other) {
+    return getAnnotatedAssetId().equals(other.getAnnotatedAssetId()) &&
+           getAnnotatedLocation().equals(other.getAnnotatedLocation()) &&
+           getAnnotatedUser().equals(other.getAnnotatedUser()) &&
+           getDeviceId().equals(other.getDeviceId()) &&
+           getSerialNumber().equals(other.getSerialNumber());
+  }
+
+  @Override
+  public int hashCode() {
+    return (deviceId.hashCode() * 1163 + serialNumber.hashCode() * 769);
   }
 }

--- a/src/main/java/com/google/sps/data/ChromeOSDevice.java
+++ b/src/main/java/com/google/sps/data/ChromeOSDevice.java
@@ -52,4 +52,26 @@ public class ChromeOSDevice {
         throw new IllegalArgumentException(fieldName + "is not a valid annotated field");
     }
   }
+
+  public String getDeviceId() {
+    return deviceId;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+
+    if (!(obj instanceof ChromeOSDevice)) {
+      return false;
+    }
+
+    ChromeOSDevice other = (ChromeOSDevice) obj;
+    return annotatedAssetId.equals(other.annotatedAssetId) &&
+        annotatedLocation.equals(other.annotatedLocation) &&
+        annotatedUser.equals(other.annotatedUser) &&
+        deviceId.equals(other.deviceId) &&
+        serialNumber.equals(other.serialNumber);
+  }
 }

--- a/src/main/java/com/google/sps/data/ChromeOSDevice.java
+++ b/src/main/java/com/google/sps/data/ChromeOSDevice.java
@@ -1,0 +1,55 @@
+package com.google.sps.data;
+
+/*
+ * Class representing a Chrome OS Device.
+ * See https://developers.google.com/admin-sdk/directory/v1/reference/chromeosdevices
+ * This class is an incomplete list of all chrome os device properties, instead containing
+ * only the subset of properties related to the webapp.  These properties can be expanded
+ * if the scope changes.
+ */
+public class ChromeOSDevice {
+
+  private String annotatedAssetId;
+  private String annotatedLocation;
+  private String annotatedUser;
+
+  private final String deviceId;
+  private final String serialNumber;
+
+  public ChromeOSDevice(
+      String annotatedAssetId,
+      String annotatedLocation,
+      String annotatedUser,
+      String deviceId,
+      String serialNumber) {
+    this.annotatedAssetId = annotatedAssetId;
+    this.annotatedLocation = annotatedLocation;
+    this.annotatedUser = annotatedUser;
+    this.deviceId = deviceId;
+    this.serialNumber = serialNumber;
+
+    sanitize();
+  }
+
+  // The Gson deserializer doesnt actually call the object's constructor, so we defined a custom
+  // deserializer which calls the sanitize() method. To keep everything consistent, the
+  // ChromeOSDevice constructor also calls the sanitize() method so the same standard is held
+  public void sanitize() {
+    annotatedAssetId = annotatedAssetId == null ? "" : annotatedAssetId;
+    annotatedLocation = annotatedLocation == null ? "" : annotatedLocation;
+    annotatedUser = annotatedUser == null ? "" : annotatedUser;
+  }
+
+  public String getAnnotatedField(String fieldName) throws IllegalArgumentException {
+    switch(fieldName) {
+      case "annotatedAssetId":
+        return annotatedAssetId;
+      case "annotatedLocation":
+        return annotatedLocation;
+      case "annotatedUser":
+        return annotatedUser;
+      default:
+        throw new IllegalArgumentException(fieldName + "is not a valid annotated field");
+    }
+  }
+}

--- a/src/main/java/com/google/sps/data/ChromeOSDevice.java
+++ b/src/main/java/com/google/sps/data/ChromeOSDevice.java
@@ -40,11 +40,12 @@ public class ChromeOSDevice {
   }
 
   public ChromeOSDevice copy() {
-    return new ChromeOSDevice(getAnnotatedAssetId(),
-                              getAnnotatedLocation(),
-                              getAnnotatedUser(),
-                              getDeviceId(),
-                              getSerialNumber());
+    return new ChromeOSDevice(
+                              annotatedAssetId,
+                              annotatedLocation,
+                              annotatedUser,
+                              deviceId,
+                              serialNumber);
   }
 
   public String getAnnotatedField(String fieldName) throws IllegalArgumentException {
@@ -96,15 +97,16 @@ public class ChromeOSDevice {
   }
 
   private boolean comparable(ChromeOSDevice other) {
-    return getAnnotatedAssetId().equals(other.getAnnotatedAssetId()) &&
-           getAnnotatedLocation().equals(other.getAnnotatedLocation()) &&
-           getAnnotatedUser().equals(other.getAnnotatedUser()) &&
-           getDeviceId().equals(other.getDeviceId()) &&
-           getSerialNumber().equals(other.getSerialNumber());
+    return annotatedAssetId.equals(other.getAnnotatedAssetId()) &&
+           annotatedLocation.equals(other.getAnnotatedLocation()) &&
+           annotatedUser.equals(other.getAnnotatedUser()) &&
+           deviceId.equals(other.getDeviceId()) &&
+           serialNumber.equals(other.getSerialNumber());
   }
 
   @Override
   public int hashCode() {
-    return (deviceId.hashCode() * 1163 + serialNumber.hashCode() * 769);
+    final String hashString = deviceId + "|" + serialNumber;
+    return hashString.hashCode();  
   }
 }

--- a/src/main/java/com/google/sps/data/ChromeOSDevice.java
+++ b/src/main/java/com/google/sps/data/ChromeOSDevice.java
@@ -41,24 +41,11 @@ public class ChromeOSDevice {
 
   public ChromeOSDevice copy() {
     return new ChromeOSDevice(
-                              annotatedAssetId,
-                              annotatedLocation,
-                              annotatedUser,
-                              deviceId,
-                              serialNumber);
-  }
-
-  public String getAnnotatedField(String fieldName) throws IllegalArgumentException {
-    switch(fieldName) {
-      case "annotatedAssetId":
-        return getAnnotatedAssetId();
-      case "annotatedLocation":
-        return getAnnotatedLocation();
-      case "annotatedUser":
-        return getAnnotatedUser();
-      default:
-        throw new IllegalArgumentException(fieldName + "is not a valid annotated field");
-    }
+        annotatedAssetId,
+        annotatedLocation,
+        annotatedUser,
+        deviceId,
+        serialNumber);
   }
 
   public String getDeviceId() {
@@ -107,6 +94,6 @@ public class ChromeOSDevice {
   @Override
   public int hashCode() {
     final String hashString = deviceId + "|" + serialNumber;
-    return hashString.hashCode();  
+    return hashString.hashCode();
   }
 }

--- a/src/main/java/com/google/sps/data/ListDeviceResponse.java
+++ b/src/main/java/com/google/sps/data/ListDeviceResponse.java
@@ -1,0 +1,29 @@
+package com.google.sps.data;
+
+import com.google.sps.data.ChromeOSDevice;
+import java.util.ArrayList;
+import java.util.List;
+
+/*
+ * Class representing response to `list Chrome OS Devices` request.
+ * See https://developers.google.com/admin-sdk/directory/v1/reference/chromeosdevices/list
+*/
+public final class ListDeviceResponse {
+
+  private final String kind;
+  private final List<ChromeOSDevice> chromeosdevices;
+  private final String nextPageToken;
+  private final String etag;
+
+  public ListDeviceResponse(String kind, List<ChromeOSDevice> chromeosdevices, String nextPageToken, String etag) {
+    this.kind = kind;
+    this.chromeosdevices = chromeosdevices;
+    this.nextPageToken = nextPageToken;
+    this.etag = etag;
+  }
+
+  public List<ChromeOSDevice> getDevices() {
+    List<ChromeOSDevice> devices = new ArrayList<>(chromeosdevices);
+    return chromeosdevices;
+  }
+}

--- a/src/main/java/com/google/sps/data/ListDeviceResponse.java
+++ b/src/main/java/com/google/sps/data/ListDeviceResponse.java
@@ -17,13 +17,20 @@ public final class ListDeviceResponse {
 
   public ListDeviceResponse(String kind, List<ChromeOSDevice> chromeosdevices, String nextPageToken, String etag) {
     this.kind = kind;
-    this.chromeosdevices = chromeosdevices;
+    this.chromeosdevices = getDeviceListCopy(chromeosdevices);
     this.nextPageToken = nextPageToken;
     this.etag = etag;
   }
 
+  public List<ChromeOSDevice> getDeviceListCopy(List<ChromeOSDevice> original) {
+    final List<ChromeOSDevice> devices = new ArrayList<>(chromeosdevices);
+    for (final ChromeOSDevice device : original) {
+      devices.add(device.copy());
+    }
+    return devices;
+  }
+
   public List<ChromeOSDevice> getDevices() {
-    List<ChromeOSDevice> devices = new ArrayList<>(chromeosdevices);
-    return chromeosdevices;
+    return getDeviceListCopy(chromeosdevices);
   }
 }

--- a/src/main/java/com/google/sps/data/ListDeviceResponse.java
+++ b/src/main/java/com/google/sps/data/ListDeviceResponse.java
@@ -23,7 +23,7 @@ public final class ListDeviceResponse {
   }
 
   public List<ChromeOSDevice> getDeviceListCopy(List<ChromeOSDevice> original) {
-    final List<ChromeOSDevice> devices = new ArrayList<>(chromeosdevices);
+    final List<ChromeOSDevice> devices = new ArrayList<>();
     for (final ChromeOSDevice device : original) {
       devices.add(device.copy());
     }

--- a/src/main/java/com/google/sps/gson/ChromeOSDeviceDeserializer.java
+++ b/src/main/java/com/google/sps/gson/ChromeOSDeviceDeserializer.java
@@ -1,0 +1,28 @@
+package com.google.sps.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
+import com.google.sps.data.ChromeOSDevice;
+import java.lang.reflect.Type;
+
+/*
+ * Custom deserializer for ChromeOSDevice objects. This is necessary because the default Gson
+ * deserializer does not use the constructor, so there is no way to sanitize the input.
+*/
+public final class ChromeOSDeviceDeserializer implements JsonDeserializer<ChromeOSDevice> {
+
+  private static final Gson gson = new Gson();
+
+  @Override
+  public ChromeOSDevice deserialize(
+      JsonElement json,
+      Type typeOfT,
+      JsonDeserializationContext context) throws JsonParseException {
+    ChromeOSDevice device = gson.fromJson(json, ChromeOSDevice.class);
+    device.sanitize();
+    return device;
+  }
+}

--- a/src/main/java/com/google/sps/gson/ChromeOSDeviceDeserializer.java
+++ b/src/main/java/com/google/sps/gson/ChromeOSDeviceDeserializer.java
@@ -14,14 +14,14 @@ import java.lang.reflect.Type;
 */
 public final class ChromeOSDeviceDeserializer implements JsonDeserializer<ChromeOSDevice> {
 
-  private static final Gson gson = new Gson();
+  private static final Gson GSON = new Gson();
 
   @Override
   public ChromeOSDevice deserialize(
       JsonElement json,
       Type typeOfT,
       JsonDeserializationContext context) throws JsonParseException {
-    ChromeOSDevice device = gson.fromJson(json, ChromeOSDevice.class);
+    final ChromeOSDevice device = GSON.fromJson(json, ChromeOSDevice.class);
     device.sanitize();
     return device;
   }

--- a/src/main/java/com/google/sps/gson/Json.java
+++ b/src/main/java/com/google/sps/gson/Json.java
@@ -1,0 +1,27 @@
+package com.google.sps.gson;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.sps.gson.ChromeOSDeviceDeserializer;
+import com.google.sps.data.ChromeOSDevice;
+
+/*
+ * Class providing the ability to serialize and deserialize Json using Gson and custom-defined
+ * deserializers where appropriate. Should be used by all classes not in this directory when
+ * needing to serialize/deserialize something.
+*/
+public class Json {
+
+  private static final Gson gson = new GsonBuilder()
+      .registerTypeAdapter(ChromeOSDevice.class, new ChromeOSDeviceDeserializer())
+      .create();
+
+
+  public static Object fromJson(String json, Class cls) {
+    return gson.fromJson(json, cls);
+  }
+
+  public static String toJson(Object obj) {
+    return gson.toJson(obj);
+  }
+}

--- a/src/main/java/com/google/sps/gson/Json.java
+++ b/src/main/java/com/google/sps/gson/Json.java
@@ -12,16 +12,16 @@ import com.google.sps.data.ChromeOSDevice;
 */
 public class Json {
 
-  private static final Gson gson = new GsonBuilder()
+  private static final Gson GSON = new GsonBuilder()
       .registerTypeAdapter(ChromeOSDevice.class, new ChromeOSDeviceDeserializer())
       .create();
 
 
   public static Object fromJson(String json, Class cls) {
-    return gson.fromJson(json, cls);
+    return GSON.fromJson(json, cls);
   }
 
   public static String toJson(Object obj) {
-    return gson.toJson(obj);
+    return GSON.toJson(obj);
   }
 }

--- a/src/test/java/com/google/sps/gson/JsonTest.java
+++ b/src/test/java/com/google/sps/gson/JsonTest.java
@@ -1,0 +1,57 @@
+package com.google.sps.gson;
+
+import com.google.sps.data.ChromeOSDevice;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/*
+ * Test the custom deserializer; assume that standard Gson functionality works properly.
+ * Thus we only need to test deserializing the ChromeOSDevice and can assume the
+ * ListDeviceResponse deserializes fine.
+*/
+@RunWith(JUnit4.class)
+public final class JsonTest {
+
+  @Test
+  public void deserializeDevice() {
+    String assetId = "ef249a";
+    String location = "California";
+    String user = "James";
+    String deviceId = "93fc2a-c09afda81";
+    String serialNumber = "SN11111";
+
+    ChromeOSDevice expected =
+        new ChromeOSDevice(assetId, location, user, deviceId, serialNumber);
+
+    ChromeOSDevice actual = (ChromeOSDevice) Json.fromJson(
+        "{\"annotatedAssetId\": \"" + assetId + "\", " +
+        "\"annotatedLocation\": \"" + location + "\", " +
+        "\"annotatedUser\": \"" + user + "\", " +
+        "\"deviceId\": \"" + deviceId + "\", " +
+        "\"serialNumber\": \"" + serialNumber + "\"}", ChromeOSDevice.class);
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void deserializeDeviceMissingField(){
+    String assetId = null;
+    String location = "New Jersey";
+    String user = null;
+    String deviceId = "ae37f0-5bd7593ca";
+    String serialNumber = "SN11111";
+
+    ChromeOSDevice expected =
+        new ChromeOSDevice(assetId, location, user, deviceId, serialNumber);
+
+    ChromeOSDevice actual = (ChromeOSDevice) Json.fromJson(
+        "{\"annotatedLocation\": \"" + location + "\", " +
+        "\"deviceId\": \"" + deviceId + "\", " +
+        "\"serialNumber\": \"" + serialNumber + "\"}", ChromeOSDevice.class);
+
+    Assert.assertEquals(expected, actual);
+  }
+
+}


### PR DESCRIPTION
Add classes representing ChromeOSDevices and the response from a request to the Admin SDK API so that Gson can be used to parse them.  Also add a custom Gson deserializer which is necessary to enforce certain criteria (e.g. non null values).