### PR TITLE
Aggregation backend functionality with fake data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+    <groupId>org.mockito</groupId>
+    <artifactId>mockito-all</artifactId>
+    <version>2.0.2-beta</version>
+    <scope>test</scope>
+</dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/google/sps/data/AnnotatedField.java
+++ b/src/main/java/com/google/sps/data/AnnotatedField.java
@@ -21,6 +21,10 @@ public enum AnnotatedField {
 
 
   public static AnnotatedField create(String fieldName) {
+    if (fieldName == null) {
+      throw new IllegalArgumentException("Annotated field name cannot be null.");
+    }
+
     switch (fieldName) {
       case "annotatedAssetId":
         return AnnotatedField.ASSET_ID;

--- a/src/main/java/com/google/sps/servlets/AggregationServlet.java
+++ b/src/main/java/com/google/sps/servlets/AggregationServlet.java
@@ -1,0 +1,87 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package com.google.sps.servlets;
+
+import com.google.sps.data.ChromeOSDevice;
+import com.google.sps.data.ListDeviceResponse;
+import com.google.sps.gson.Json;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+/** Servlet that aggregates chrome devices by a given field */
+@WebServlet("/aggregate")
+public class AggregationServlet extends HttpServlet {
+
+  // Used for testing
+  public AggregationServlet() {}
+
+  private static final Set<String> aggregableFields =
+      new HashSet<>(Arrays.asList("annotatedAssetId, annotatedLocation, annotatedUser"));
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    response.setContentType("application/json;");
+
+    String aggregationField = request.getParameter("aggregationField");
+    if (!isValidField(aggregationField)) {
+      response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+      response.getWriter().println(aggregationField + " is not a valid aggregation field");
+      return;
+    }
+
+    List<ChromeOSDevice> devices = amassDevices();
+    Map<String, Integer> data = processData(devices, aggregationField);
+
+    response.getWriter().println(Json.toJson(data));
+  }
+
+  public List<ChromeOSDevice> amassDevices() {
+    List<ChromeOSDevice> devices = new ArrayList<>();
+
+    // TODO: Send requests to API to get all devices; requires OAuth
+
+    // Some mock devices so we have data in the interim
+    devices.add(new ChromeOSDevice("assetId", "location", "user", "deviceId", "serialNumber"));
+    devices.add(new ChromeOSDevice("12345", "California", "Jane", "ae25f1-91ce6a", "SN54321"));
+
+    return devices;
+  }
+
+  public Map<String, Integer> processData(List<ChromeOSDevice> devices, String aggregationField) {
+    Map<String, Integer> counts = new HashMap<>();
+
+    for (ChromeOSDevice device : devices) {
+      String fieldValue = device.getAnnotatedField(aggregationField);
+      Integer newVal = counts.getOrDefault(fieldValue, new Integer(0)).intValue() + 1;
+      counts.put(fieldValue, newVal);
+    }
+
+    return counts;
+  }
+
+  private boolean isValidField(String field) {
+    return aggregableFields.contains(field);
+  }
+}

--- a/src/test/java/com/google/sps/data/AnnotatedFieldTest.java
+++ b/src/test/java/com/google/sps/data/AnnotatedFieldTest.java
@@ -1,0 +1,41 @@
+package com.google.sps.data;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/*
+ * Ensure that the AnnotatedField.create() method throws the correct errors when
+ * given illegal input.  Test that the getField() method works correctly.
+ */
+@RunWith(JUnit4.class)
+public final class AnnotatedFieldTest {
+
+  @Test(expected = IllegalArgumentException.class)
+  public void invalidFieldName() {
+    AnnotatedField.create("serialNumber");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void nullFieldName() {
+    AnnotatedField.create(null);
+  }
+
+  @Test
+  public void properFieldName() {
+    AnnotatedField field = AnnotatedField.create("annotatedLocation");
+
+    Assert.assertEquals(AnnotatedField.LOCATION, field);
+  }
+
+  @Test
+  public void getsCorrectField() {
+    AnnotatedField field = AnnotatedField.create("annotatedUser");
+
+    ChromeOSDevice device = new ChromeOSDevice("assetId", "location", "user", "deviceId", "serialNumber");
+
+    Assert.assertEquals(device.getAnnotatedUser(), field.getField(device));
+  }
+
+}

--- a/src/test/java/com/google/sps/servlets/AggregationServletTest.java
+++ b/src/test/java/com/google/sps/servlets/AggregationServletTest.java
@@ -1,0 +1,91 @@
+package com.google.sps.servlets;
+
+import com.google.sps.data.ChromeOSDevice;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/*
+ * Test the aggregation functionality to ensure it reports accurate counts and
+ * throws errors when appropriate.  Eventually will need to add tests for
+ * aggregating by multiple fields at once.
+ */
+@RunWith(JUnit4.class)
+public final class AggregationServletTest {
+
+  private final String LOCATION_ONE = "New Jersey";
+  private final String LOCATION_TWO = "California";
+
+  private final String USER_ONE = "James";
+  private final String USER_TWO = "Josiah";
+  private final String USER_THREE = "Jeremy";
+
+  private final String ASSET_ID_ONE = "12345";
+
+  private final ChromeOSDevice DEVICE_ONE =
+      new ChromeOSDevice(ASSET_ID_ONE, LOCATION_ONE, USER_ONE, "deviceId", "serialNumber");
+  private final ChromeOSDevice DEVICE_TWO =
+      new ChromeOSDevice(ASSET_ID_ONE, LOCATION_ONE, USER_TWO, "deviceId", "serialNumber");
+  private final ChromeOSDevice DEVICE_THREE =
+      new ChromeOSDevice(ASSET_ID_ONE, LOCATION_TWO, USER_THREE, "deviceId", "serialNumber");
+  private final ChromeOSDevice DEVICE_FOUR =
+      new ChromeOSDevice(ASSET_ID_ONE, LOCATION_TWO, USER_ONE, "deviceId", "serialNumber");
+  private final ChromeOSDevice DEVICE_FIVE =
+      new ChromeOSDevice(ASSET_ID_ONE, LOCATION_ONE, USER_THREE, "deviceId", "serialNumber");
+
+  private final List<ChromeOSDevice> allDevices = new ArrayList<>(
+      Arrays.asList(DEVICE_ONE, DEVICE_TWO, DEVICE_THREE, DEVICE_FOUR, DEVICE_FIVE));
+
+  @Test
+  public void onlyOneUniqueField() {
+    AggregationServlet servlet = new AggregationServlet();
+
+    Map<String, Integer> expected = new HashMap<>();
+    expected.put(ASSET_ID_ONE, 5);
+
+    Map<String, Integer> actual = servlet.processData(allDevices, "annotatedAssetId");
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void manyFields() {
+    AggregationServlet servlet = new AggregationServlet();
+
+    Map<String, Integer> expected = new HashMap<>();
+    expected.put(USER_ONE, 2);
+    expected.put(USER_TWO, 1);
+    expected.put(USER_THREE, 2);
+
+    Map<String, Integer> actual = servlet.processData(allDevices, "annotatedUser");
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void annotatedLocation() {
+    AggregationServlet servlet = new AggregationServlet();
+
+    Map<String, Integer> expected = new HashMap<>();
+    expected.put(LOCATION_ONE, 3);
+    expected.put(LOCATION_TWO, 2);
+
+    Map<String, Integer> actual = servlet.processData(allDevices, "annotatedLocation");
+
+    Assert.assertEquals(expected, actual);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void invalidArgument() {
+    AggregationServlet servlet = new AggregationServlet();
+
+    Map<String, Integer> actual = servlet.processData(allDevices, "deviceId");
+  }
+
+}


### PR DESCRIPTION
Add backend functionality for Aggregation by given field, except using fake data instead of real data.  Need OAuth support before real data can be used.  Add tests for aggregating by each field as well as ensuring errors are thrown appropriately.