### PR TITLE
Parallel Updating

### DIFF
--- a/src/main/java/com/google/sps/servlets/UpdateServlet.java
+++ b/src/main/java/com/google/sps/servlets/UpdateServlet.java
@@ -50,12 +50,11 @@ public class UpdateServlet extends HttpServlet {
     final String updatesInJson = getJsonFromMap(updatesToMake);
     final String relevantDeviceIds = request.getParameter(DEVICE_IDS_PARAMETER_NAME);
     final List<String> deviceIds = getDeviceIds(relevantDeviceIds);
-    List<String> failedUpdateDeviceIds = new ArrayList<>(); 
     if (!deviceIds.isEmpty() && !updatesToMake.isEmpty()) {
       List<String> failedUpdateDeviceIds = utilObj.updateDevices(userId, deviceIds, updatesInJson);
       if (!failedUpdateDeviceIds.isEmpty()) {
         response.setContentType("application/json");
-        final String json = GSON_OBJECT.toJson(allDevices);
+        final String json = GSON_OBJECT.toJson(failedUpdateDeviceIds);
         response.getWriter().println(json);
       }
     }

--- a/src/main/java/com/google/sps/servlets/UpdateServlet.java
+++ b/src/main/java/com/google/sps/servlets/UpdateServlet.java
@@ -56,7 +56,10 @@ public class UpdateServlet extends HttpServlet {
         response.setContentType("application/json");
         final String json = GSON_OBJECT.toJson(failedUpdateDeviceIds);
         response.getWriter().println(json);
-      }
+        response.setStatus(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
+      } else {
+        response.setStatus(HttpServletResponse.SC_OK);
+      } 
     }
     response.sendRedirect(INDEX_URL);
     return;

--- a/src/main/java/com/google/sps/servlets/UpdateServlet.java
+++ b/src/main/java/com/google/sps/servlets/UpdateServlet.java
@@ -16,6 +16,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,10 +48,16 @@ public class UpdateServlet extends HttpServlet {
       }
     }
     final String updatesInJson = getJsonFromMap(updatesToMake);
-    final String relevantDeviceIds = (String) request.getParameter(DEVICE_IDS_PARAMETER_NAME);
+    final String relevantDeviceIds = request.getParameter(DEVICE_IDS_PARAMETER_NAME);
     final List<String> deviceIds = getDeviceIds(relevantDeviceIds);
+    List<String> failedUpdateDeviceIds = new ArrayList<>(); 
     if (!deviceIds.isEmpty() && !updatesToMake.isEmpty()) {
-      utilObj.updateDevices(userId, deviceIds, updatesInJson);
+      List<String> failedUpdateDeviceIds = utilObj.updateDevices(userId, deviceIds, updatesInJson);
+      if (!failedUpdateDeviceIds.isEmpty()) {
+        response.setContentType("application/json");
+        final String json = GSON_OBJECT.toJson(allDevices);
+        response.getWriter().println(json);
+      }
     }
     response.sendRedirect(INDEX_URL);
     return;

--- a/src/main/java/com/google/sps/servlets/Util.java
+++ b/src/main/java/com/google/sps/servlets/Util.java
@@ -172,6 +172,7 @@ class Util {
     datastore.put(tokenEntity);
   }
 
+  //Returns a list of failed device Ids that failed to update, empty if all devices were successfully updated
   public List<String> updateDevices(String userId, List<String> deviceIds, String updatesInJson) throws IOException {
     final String accessToken = getAccessToken(userId);
     final List<String> failedUpdateDeviceIds = Collections.synchronizedList(new ArrayList<String>());

--- a/src/main/java/com/google/sps/servlets/Util.java
+++ b/src/main/java/com/google/sps/servlets/Util.java
@@ -49,6 +49,7 @@ import com.squareup.okhttp.Request;
 import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 class Util {

--- a/src/main/java/com/google/sps/servlets/Util.java
+++ b/src/main/java/com/google/sps/servlets/Util.java
@@ -163,6 +163,14 @@ class Util {
     return refreshToken;
   }
 
+  public void associateRefreshToken(String userId, String refreshToken) {
+    Entity tokenEntity = new Entity("RefreshToken");
+    tokenEntity.setProperty("userId", userId);
+    tokenEntity.setProperty("refreshToken", refreshToken);
+    deleteStaleTokens(userId);
+    datastore.put(tokenEntity);
+  }
+
   public void updateDevices(String userId, List<String> deviceIds, String updatesInJson) throws IOException {
     final String accessToken = getAccessToken(userId);
     deviceIds
@@ -181,8 +189,8 @@ class Util {
 
   private void updateSingleDevice(String accessToken, String deviceId, String updatesInJson) throws IOException {
     final String updateUrl = getUpdateUrl(deviceId);
-    RequestBody body = RequestBody.create(JSON, updatesInJson);
-    Request req = new Request.Builder().url(myUrl).put(body).addHeader("Authorization", "Bearer " + accessToken).build();
+    RequestBody body = RequestBody.create(JSON_TYPE, updatesInJson);
+    Request req = new Request.Builder().url(updateUrl).put(body).addHeader("Authorization", "Bearer " + accessToken).build();
     Response updateResponse = client.newCall(req).execute();
     updateResponse.body().close();
   }

--- a/src/main/java/com/google/sps/servlets/Util.java
+++ b/src/main/java/com/google/sps/servlets/Util.java
@@ -183,6 +183,7 @@ class Util {
             updateSingleDevice(accessToken, deviceId, updatesInJson);
           } catch (IOException e) {
             failedUpdateDeviceIds.add(deviceId);
+            System.out.println("Device failed to update: " + deviceId);
           }
         }
       );

--- a/src/main/java/com/google/sps/servlets/Util.java
+++ b/src/main/java/com/google/sps/servlets/Util.java
@@ -163,23 +163,28 @@ class Util {
     return refreshToken;
   }
 
-  public void associateRefreshToken(String userId, String refreshToken) {
-    Entity tokenEntity = new Entity("RefreshToken");
-    tokenEntity.setProperty("userId", userId);
-    tokenEntity.setProperty("refreshToken", refreshToken);
-    deleteStaleTokens(userId);
-    datastore.put(tokenEntity);
-  }
-
   public void updateDevices(String userId, List<String> deviceIds, String updatesInJson) throws IOException {
     final String accessToken = getAccessToken(userId);
-    for (final String deviceId : deviceIds) {
-      final String updateURL = getUpdateUrl(deviceId);
-      RequestBody body = RequestBody.create(JSON_TYPE, updatesInJson);
-      Request req = new Request.Builder().url(updateURL).put(body).addHeader("Authorization", "Bearer " + accessToken).build();
-      Response updateResponse = client.newCall(req).execute();
-      updateResponse.body().close();
-    }
+    deviceIds
+      .parallelStream()
+      .forEach(
+        deviceId -> {
+          try {
+            updateSingleDevice(accessToken, deviceId, updatesInJson);
+          } catch (IOException e) {
+            System.out.println(deviceId);
+            System.out.println("had an error");//TODO: handle and return failed devices
+          }
+        }
+      );
+  }
+
+  private void updateSingleDevice(String accessToken, String deviceId, String updatesInJson) throws IOException {
+    final String updateUrl = getUpdateUrl(deviceId);
+    RequestBody body = RequestBody.create(JSON, updatesInJson);
+    Request req = new Request.Builder().url(myUrl).put(body).addHeader("Authorization", "Bearer " + accessToken).build();
+    Response updateResponse = client.newCall(req).execute();
+    updateResponse.body().close();
   }
 
   private String getUpdateUrl(String deviceId) {

--- a/src/main/java/com/google/sps/servlets/Util.java
+++ b/src/main/java/com/google/sps/servlets/Util.java
@@ -171,8 +171,9 @@ class Util {
     datastore.put(tokenEntity);
   }
 
-  public void updateDevices(String userId, List<String> deviceIds, String updatesInJson) throws IOException {
+  public List<String> updateDevices(String userId, List<String> deviceIds, String updatesInJson) throws IOException {
     final String accessToken = getAccessToken(userId);
+    final List<String> failedUpdateDeviceIds = Collections.synchronizedList(new ArrayList<String>());
     deviceIds
       .parallelStream()
       .forEach(
@@ -180,11 +181,11 @@ class Util {
           try {
             updateSingleDevice(accessToken, deviceId, updatesInJson);
           } catch (IOException e) {
-            System.out.println(deviceId);
-            System.out.println("had an error");//TODO: handle and return failed devices
+            failedUpdateDeviceIds.add(deviceId);
           }
         }
       );
+    return failedUpdateDeviceIds;
   }
 
   private void updateSingleDevice(String accessToken, String deviceId, String updatesInJson) throws IOException {

--- a/src/test/java/com/google/sps/servlets/UpdateServletTest.java
+++ b/src/test/java/com/google/sps/servlets/UpdateServletTest.java
@@ -224,7 +224,7 @@ public final class UpdateServletTest {
     Assert.assertEquals(expected, result);
   }
 
-  private void verifyUniversalUpdateExecution() {
+  private void verifyUniversalUpdateExecution() throws IOException {
     verify(response).sendRedirect(servlet.INDEX_URL);
     verify(mockedUserService, times(1)).isUserLoggedIn();
     verify(request, times(1)).getParameter("annotatedLocation");

--- a/src/test/java/com/google/sps/servlets/UpdateServletTest.java
+++ b/src/test/java/com/google/sps/servlets/UpdateServletTest.java
@@ -16,11 +16,14 @@ import com.squareup.okhttp.RequestBody;
 import com.squareup.okhttp.Response;
 import org.json.simple.JSONArray;
 import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.lang.reflect.Type;
 import java.security.GeneralSecurityException;
 import java.util.ArrayList;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -58,15 +61,17 @@ public final class UpdateServletTest {
   private UserService mockedUserService;
   private Util mockedUtil;
   private User userFake;
+  private StringWriter stringWriter;
+  private PrintWriter writer;
 
   @Before
-  public void setUp() {
+  public void setUp() throws IOException {
     mockedUserService = mock(UserService.class);
     mockedUtil = mock(Util.class);
     userFake = new User(TEST_USER_EMAIL, TEST_USER_AUTH_DOMAIN, TEST_USER_ID);
 
-    StringWriter stringWriter = new StringWriter();
-    PrintWriter writer = new PrintWriter(stringWriter);
+    stringWriter = new StringWriter();
+    writer = new PrintWriter(stringWriter);
     when(response.getWriter()).thenReturn(writer);
 
     servlet.setUserService(mockedUserService);
@@ -192,7 +197,35 @@ public final class UpdateServletTest {
     
     verify(response).setContentType("application/json");
     String result = stringWriter.getBuffer().toString().trim();
-    String expected = "{}";
+    String expected = "[\"device1\"]";
+    Assert.assertEquals(expected, result);
+  }
+
+  @Test
+  public void testOnAllDeviceFailed() throws IOException {
+    when(mockedUserService.isUserLoggedIn()).thenReturn(true);
+    when(mockedUserService.getCurrentUser()).thenReturn(userFake);
+
+    when(request.getParameter("annotatedLocation")).thenReturn(null);
+    when(request.getParameter("annotatedAssetId")).thenReturn("ABC123");
+    when(request.getParameter("annotatedUser")).thenReturn(null);
+    when(request.getParameter(servlet.DEVICE_IDS_PARAMETER_NAME)).thenReturn("[device1, device2]");
+
+    when(mockedUtil.updateDevices(TEST_USER_ID, Arrays.asList("device1", "device2"), "{\"annotatedAssetId\":\"ABC123\"}")).thenReturn(Arrays.asList("device1","device2"));
+
+    servlet.doPost(request, response);
+
+    verify(response).sendRedirect(servlet.INDEX_URL);
+    verify(mockedUserService, times(1)).isUserLoggedIn();
+    verify(request, times(1)).getParameter("annotatedLocation");
+    verify(request, times(1)).getParameter("annotatedAssetId");
+    verify(request, times(1)).getParameter("annotatedUser");
+    verify(request, times(1)).getParameter(servlet.DEVICE_IDS_PARAMETER_NAME);
+    verify(mockedUtil, times(1)).updateDevices(TEST_USER_ID, Arrays.asList("device1", "device2"), "{\"annotatedAssetId\":\"ABC123\"}");
+    
+    verify(response).setContentType("application/json");
+    String result = stringWriter.getBuffer().toString().trim();
+    String expected = "[\"device1\",\"device2\"]";
     Assert.assertEquals(expected, result);
   }
 

--- a/src/test/java/com/google/sps/servlets/UpdateServletTest.java
+++ b/src/test/java/com/google/sps/servlets/UpdateServletTest.java
@@ -215,18 +215,22 @@ public final class UpdateServletTest {
 
     servlet.doPost(request, response);
 
-    verify(response).sendRedirect(servlet.INDEX_URL);
-    verify(mockedUserService, times(1)).isUserLoggedIn();
-    verify(request, times(1)).getParameter("annotatedLocation");
-    verify(request, times(1)).getParameter("annotatedAssetId");
-    verify(request, times(1)).getParameter("annotatedUser");
-    verify(request, times(1)).getParameter(servlet.DEVICE_IDS_PARAMETER_NAME);
+    verifyUniversalUpdateExecution();
     verify(mockedUtil, times(1)).updateDevices(TEST_USER_ID, Arrays.asList("device1", "device2"), "{\"annotatedAssetId\":\"ABC123\"}");
     
     verify(response).setContentType("application/json");
     String result = stringWriter.getBuffer().toString().trim();
     String expected = "[\"device1\",\"device2\"]";
     Assert.assertEquals(expected, result);
+  }
+
+  private void verifyUniversalUpdateExecution() {
+    verify(response).sendRedirect(servlet.INDEX_URL);
+    verify(mockedUserService, times(1)).isUserLoggedIn();
+    verify(request, times(1)).getParameter("annotatedLocation");
+    verify(request, times(1)).getParameter("annotatedAssetId");
+    verify(request, times(1)).getParameter("annottedUser");
+    verify(request, times(1)).getParameter(servlet.DEVICE_IDS_PARAMETER_NAME);
   }
 
 }

--- a/src/test/java/com/google/sps/servlets/UpdateServletTest.java
+++ b/src/test/java/com/google/sps/servlets/UpdateServletTest.java
@@ -103,12 +103,7 @@ public final class UpdateServletTest {
 
     servlet.doPost(request, response);
 
-    verify(response).sendRedirect(servlet.INDEX_URL);
-    verify(mockedUserService, times(1)).isUserLoggedIn();
-    verify(request, times(1)).getParameter("annotatedLocation");
-    verify(request, times(1)).getParameter("annotatedAssetId");
-    verify(request, times(1)).getParameter("annotatedUser");
-    verify(request, times(1)).getParameter(servlet.DEVICE_IDS_PARAMETER_NAME);
+    verifyUniversalUpdateExecution();
   }
 
   @Test
@@ -123,12 +118,7 @@ public final class UpdateServletTest {
 
     servlet.doPost(request, response);
 
-    verify(response).sendRedirect(servlet.INDEX_URL);
-    verify(mockedUserService, times(1)).isUserLoggedIn();
-    verify(request, times(1)).getParameter("annotatedLocation");
-    verify(request, times(1)).getParameter("annotatedAssetId");
-    verify(request, times(1)).getParameter("annotatedUser");
-    verify(request, times(1)).getParameter(servlet.DEVICE_IDS_PARAMETER_NAME);
+    verifyUniversalUpdateExecution();
   }
 
   @Test
@@ -143,12 +133,7 @@ public final class UpdateServletTest {
 
     servlet.doPost(request, response);
 
-    verify(response).sendRedirect(servlet.INDEX_URL);
-    verify(mockedUserService, times(1)).isUserLoggedIn();
-    verify(request, times(1)).getParameter("annotatedLocation");
-    verify(request, times(1)).getParameter("annotatedAssetId");
-    verify(request, times(1)).getParameter("annotatedUser");
-    verify(request, times(1)).getParameter(servlet.DEVICE_IDS_PARAMETER_NAME);
+    verifyUniversalUpdateExecution();
     verify(mockedUtil, times(1)).updateDevices(TEST_USER_ID, Arrays.asList("device1"), "{\"annotatedUser\":\"bob\"}");
   }
 
@@ -164,12 +149,7 @@ public final class UpdateServletTest {
 
     servlet.doPost(request, response);
 
-    verify(response).sendRedirect(servlet.INDEX_URL);
-    verify(mockedUserService, times(1)).isUserLoggedIn();
-    verify(request, times(1)).getParameter("annotatedLocation");
-    verify(request, times(1)).getParameter("annotatedAssetId");
-    verify(request, times(1)).getParameter("annotatedUser");
-    verify(request, times(1)).getParameter(servlet.DEVICE_IDS_PARAMETER_NAME);
+    verifyUniversalUpdateExecution();
     verify(mockedUtil, times(1)).updateDevices(TEST_USER_ID, Arrays.asList("device1", "device2"), "{\"annotatedAssetId\":\"ABC123\"}");
   }
 
@@ -187,12 +167,7 @@ public final class UpdateServletTest {
 
     servlet.doPost(request, response);
 
-    verify(response).sendRedirect(servlet.INDEX_URL);
-    verify(mockedUserService, times(1)).isUserLoggedIn();
-    verify(request, times(1)).getParameter("annotatedLocation");
-    verify(request, times(1)).getParameter("annotatedAssetId");
-    verify(request, times(1)).getParameter("annotatedUser");
-    verify(request, times(1)).getParameter(servlet.DEVICE_IDS_PARAMETER_NAME);
+    verifyUniversalUpdateExecution();
     verify(mockedUtil, times(1)).updateDevices(TEST_USER_ID, Arrays.asList("device1", "device2"), "{\"annotatedAssetId\":\"ABC123\"}");
     
     verify(response).setContentType("application/json");
@@ -229,7 +204,7 @@ public final class UpdateServletTest {
     verify(mockedUserService, times(1)).isUserLoggedIn();
     verify(request, times(1)).getParameter("annotatedLocation");
     verify(request, times(1)).getParameter("annotatedAssetId");
-    verify(request, times(1)).getParameter("annottedUser");
+    verify(request, times(1)).getParameter("annotatedUser");
     verify(request, times(1)).getParameter(servlet.DEVICE_IDS_PARAMETER_NAME);
   }
 


### PR DESCRIPTION
This PR provides a dramatic speedup of bulk updating by taking advantage of multiple threads operating and sending out update requests simultaneously.

This functionality is achieved mainly through the use of parallelizing streaming -- this precludes the occurrence of typical bugs related to multithreading such as deadlock, race conditions, etc. All tasks (sending out update requests) will take roughly the same amount of time, so we are not concerned about starvation.

Authorization flow screenshots are not included below because it is still broken.

![image](https://user-images.githubusercontent.com/22208219/91557127-e980e880-e901-11ea-8146-677bdab5ccaf.png)
![image](https://user-images.githubusercontent.com/22208219/91557146-f56caa80-e901-11ea-8109-4c1c0c89c351.png)
![image](https://user-images.githubusercontent.com/22208219/91557170-00bfd600-e902-11ea-99e4-56f0803cb8bd.png)
![image](https://user-images.githubusercontent.com/22208219/91557195-0ae1d480-e902-11ea-8eab-41a7c30c8c13.png)
