### PR TITLE
Filter deprovisioned and disabled devices out of views

### DIFF
--- a/src/main/java/com/google/sps/servlets/Util.java
+++ b/src/main/java/com/google/sps/servlets/Util.java
@@ -68,6 +68,7 @@ class Util {
   private static final String DEFAULT_MAX_DEVICES = "200"; //is limited to effectively 200
   private static final String DEFAULT_SORT_ORDER = "ASCENDING";
   private static final String DEFAULT_PROJECTION = "FULL";
+  private static final String FILTER_ONLY_ACTIVE_DEVICES = "status:provisioned";
   private static final DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
   public static final MediaType JSON_TYPE = MediaType.parse("application/json; charset=utf-8");
 
@@ -127,6 +128,7 @@ class Util {
     urlBuilder.addQueryParameter("maxResults", maxDeviceCount);
 
     urlBuilder.addQueryParameter("projection", DEFAULT_PROJECTION);
+    urlBuilder.addQueryParameter("query", FILTER_ONLY_ACTIVE_DEVICES);
     urlBuilder.addQueryParameter("sortOrder", DEFAULT_SORT_ORDER);
     urlBuilder.addQueryParameter("key", apiKey);
     if (!pageToken.equals(EMPTY_PAGE_TOKEN)) {


### PR DESCRIPTION
In most use cases the users are only concerned with seeing active devices.  Thus, as the default setting we should only include active devices in the aggregations and in the main table view.

![Screenshot 2020-09-03 at 5 59 10 PM](https://user-images.githubusercontent.com/24768835/92177806-320f3900-ee0f-11ea-864b-4e0bae966479.png)
Notice that there are no deprovisioned or disabled devices on page 1, whereas previously there were several.